### PR TITLE
Fix the logical bug in `EnumField`

### DIFF
--- a/drf_rehive_extras/fields.py
+++ b/drf_rehive_extras/fields.py
@@ -81,6 +81,8 @@ class EnumField(serializers.ChoiceField):
 
     def to_internal_value(self, data):
         try:
+            if not self.choices.get(data):
+                raise ValueError
             return self.enum(data)
         except ValueError:
             self.fail('invalid_choice', input=data)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from codecs import open
 from setuptools import find_packages, setup
 
 
-VERSION = '1.0.2'
+VERSION = '1.0.4'
 
 with open(os.path.join(os.path.dirname(__file__), 'README.md')) as readme:
     README = readme.read()

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from codecs import open
 from setuptools import find_packages, setup
 
 
-VERSION = '1.0.4'
+VERSION = '1.0.3'
 
 with open(os.path.join(os.path.dirname(__file__), 'README.md')) as readme:
     README = readme.read()


### PR DESCRIPTION
- Here we add  `choices` attribute. However, in the `to_internal_value` we didn't check if the value is in the choices list or not.
For example: Consider the flowing `Enum`
```python
class AccountAction(Enum):
    WITHDRAW = 'withdraw'
    DEPOSIT = 'deposit'
```
Now for the `EnumField`
```python
    action = EnumField(
        enum=AccountAction,
        choices=tuple(('withdraw', 'WITHDRAW'),),
        required=False
    )
```
This `action` field should raise `exception` if any one try to initialize the `action` field with a value that is not present in the `choices` list. But in this case if we try to initialize the `action` field with value of `deposit` it will process further rather that rasing `exception`.